### PR TITLE
task 1 : 氏名の部分一致検索

### DIFF
--- a/backend-ts/src/employee/Employee.ts
+++ b/backend-ts/src/employee/Employee.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 export const EmployeeT = t.type({
   id: t.string,
   name: t.string,
-  name_en : t.string,
+  name_en: t.string,
   age: t.number,
   department: t.string,
   position: t.string,

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -35,18 +35,24 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
     });
   }
 
-  // 氏名の部分一致
-  partialMatchOnName(employee : Employee, filterText : string) : boolean {
-    // すべて小文字に変換
-    const lowerName : string = employee.name.toLowerCase();
-    const lowerNameEn : string = employee.name_en.toLowerCase();
-    const lowerFilter : string = filterText.toLowerCase();
-    // スペースを除去
-    const lowerNameReplaced : string = lowerName.replace(/\s+/g, "");
-    const lowerNameEnReplaced : string = lowerNameEn.replace(/\s+/g, "");
-    const lowerFilterReplaced : string = lowerFilter.replace(/\s+/g, "");
-    return (lowerName.indexOf(lowerFilter) > -1) || (lowerNameReplaced.indexOf(lowerFilterReplaced) > -1)
-        || (lowerNameEn.indexOf(lowerFilter) > -1) || (lowerNameEnReplaced.indexOf(lowerFilterReplaced) > -1);
+  // 各名前で検索
+  partialMatchByName(name: string, filterText: string): boolean {
+    const lowerName: string = name.toLowerCase();
+    const lowerNameReplaced: string = lowerName.replace(/\s+/g, "");
+    const lowerFilter: string = filterText.toLowerCase();
+
+    return (
+      lowerName.indexOf(lowerFilter) > -1 ||
+      lowerNameReplaced.indexOf(lowerFilter) > -1
+    );
+  }
+
+  // 各個人で名前の部分一致検索
+  partialMatchByEmployee(employee: Employee, filterText: string): boolean {
+    return (
+      this.partialMatchByName(employee.name, filterText) ||
+      this.partialMatchByName(employee.name_en, filterText)
+    );
   }
 
   async getEmployee(id: string): Promise<Employee | undefined> {
@@ -58,6 +64,8 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
     if (filterText === "") {
       return employees;
     }
-    return employees.filter((employee) => this.partialMatchOnName(employee, filterText));
+    return employees.filter((employee) =>
+      this.partialMatchByEmployee(employee, filterText),
+    );
   }
 }


### PR DESCRIPTION
氏名の部分一致検索を実装しました。

大文字小文字の区別や、空白の有無の区別をつけずに検索が可能です。
また、従業員情報に英語名を追加し、ローマ字でも検索が行えるようになりました。

先ほどのプルリクエストから、検索関数を使いまわせる構造に修正し、CIを通しました。